### PR TITLE
Renamed the package in prep for integration into notebook-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "lezer-javascript",
+  "name": "@observablehq/lezer",
   "version": "0.9.1",
-  "description": "lezer-based JavaScript grammar",
+  "description": "lezer-based Observable grammar, forked from lezer-javascript",
   "main": "dist/index.cjs",
   "type": "module",
   "exports": {


### PR DESCRIPTION
This renames the package to follow our naming convention, and differentiate from the official lezer-javascript module that's already in the npm registry.

This step is necessary for wiring this module into Notebook Next's package.json file. We will import it the same way we do [the Observable compiler](https://github.com/observablehq/observablehq/blob/2d62eca/notebook-next/package.json#L18) and friends.