### PR TITLE
Pull in upstream changes from 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.15.0 (2021-08-11)
+
+### Breaking changes
+
+The module's name changed from `lezer-javascript` to `@lezer/javascript`.
+
+Upgrade to the 0.15.0 lezer interfaces.
+
 ## 0.13.4 (2021-04-30)
 
 ### Bug fixes

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,3 @@
-import {Parser} from "lezer"
+import {LRParser} from "@lezer/lr"
 
-export const parser: Parser
+export const parser: LRParser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lezer/javascript",
-  "version": "0.13.4",
+  "version": "0.15.0",
   "description": "lezer-based JavaScript grammar",
   "main": "dist/index.cjs",
   "type": "module",
@@ -13,13 +13,13 @@
   "author": "Marijn Haverbeke <marijnh@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@lezer/generator": "^0.13.0",
+    "@lezer/generator": "^0.15.0",
     "mocha": "^9.0.1",
     "rollup": "^2.52.2",
     "@rollup/plugin-node-resolve": "^9.0.0"
   },
   "dependencies": {
-    "@lezer/lr": "^0.13.0"
+    "@lezer/lr": "^0.15.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lezer-javascript",
+  "name": "@lezer/javascript",
   "version": "0.13.4",
   "description": "lezer-based JavaScript grammar",
   "main": "dist/index.cjs",
@@ -13,13 +13,13 @@
   "author": "Marijn Haverbeke <marijnh@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "lezer-generator": "^0.13.0",
-    "mocha": "^8.1.3",
-    "rollup": "^2.27.1",
+    "@lezer/generator": "^0.13.0",
+    "mocha": "^9.0.1",
+    "rollup": "^2.52.2",
     "@rollup/plugin-node-resolve": "^9.0.0"
   },
   "dependencies": {
-    "lezer": "^0.13.0"
+    "@lezer/lr": "^0.13.0"
   },
   "repository": {
     "type": "git",

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -30,8 +30,8 @@
   ImportDeclaration |
   Block |
   ExpressionStatement |
-  NamedBlockCell { (VariableDefinition | QualifiedVariableDefinition) !cellname "=" Block } |
-  NamedExpressionCell { (VariableDefinition | QualifiedVariableDefinition) !cellname "=" expression semi } |
+  NamedBlockCell[@dynamicPrecedence=1] { (VariableDefinition | QualifiedVariableDefinition) !cellname "=" Block } |
+  NamedExpressionCell[@dynamicPrecedence=1] { (VariableDefinition | QualifiedVariableDefinition) !cellname "=" expression semi } |
   NamedClassCell { kw<"class"> !cellname VariableDefinition (kw<"extends"> expression)? ClassBody } |
   NamedFunctionCell { async? kw<"function"> Star? !cellname VariableDefinition ParamList Block }
 }

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -523,6 +523,8 @@ questionOp[@name=LogicOp] { "?" }
 
 @skip { whitespace | LineComment | BlockComment }
 
+@context trackNewline from "./tokens.js"
+
 @external extend { identifier } tsExtends from "./tokens" { TSExtends[@name=extends] }
 
 @external tokens noSemicolon from "./tokens" { noSemi }
@@ -539,10 +541,11 @@ questionOp[@name=LogicOp] { "?" }
 }
 
 @tokens {
-  whitespace { std.whitespace+ }
+  whitespace[@export] { std.whitespace+ }
 
   LineComment { "//" ![\n]* }
 
+  // FIXME split into multiple tokens
   BlockComment { "/*" blockCommentRest }
 
   blockCommentRest { ![*] blockCommentRest | "*" blockCommentAfterStar }

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -362,6 +362,7 @@ type[@isGroup=Type] {
    boolean |
    String
   } |
+  TemplateType |
   VoidType { kw<"void"> } |
   TypeofType { kw<"typeof"> (VariableName | typeofMemberExpression) } |
   KeyofType { !typePrefix tskw<"keyof"> type } |
@@ -422,9 +423,15 @@ ParamTypeList[@name=ParamList] {
   TemplateString {
     templateStart (templateContent | templateExpr)* templateEnd
   }
+
+  TemplateType {
+    templateStart (templateContent | templateType)* templateEnd
+  }
 }
 
 templateExpr { templateDollarBrace expression templateClosingBrace }
+
+templateType { templateDollarBrace type templateClosingBrace }
 
 @skip {} {
   JSXElement {

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -521,7 +521,7 @@ Optional { "?" }
 
 questionOp[@name=LogicOp] { "?" }
 
-@skip { whitespace | LineComment | BlockComment }
+@skip { spaces | newline | LineComment | BlockComment }
 
 @context trackNewline from "./tokens.js"
 
@@ -541,7 +541,8 @@ questionOp[@name=LogicOp] { "?" }
 }
 
 @tokens {
-  whitespace[@export] { std.whitespace+ }
+  spaces[@export] { $[\u0009 \u000b\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]+ }
+  newline[@export] { $[\r\n\u2028\u2029] }
 
   LineComment { "//" ![\n]* }
 
@@ -564,11 +565,11 @@ questionOp[@name=LogicOp] { "?" }
 
   identifier { word }
 
-  @precedence { identifier, whitespace }
+  @precedence { spaces, newline, identifier }
 
-  @precedence { JSXIdentifier, whitespace }
+  @precedence { spaces, newline, JSXIdentifier }
 
-  @precedence { word, whitespace }
+  @precedence { spaces, newline, word }
 
   Number {
     (std.digit ("_" | std.digit)* ("." ("_" | std.digit)*)? | "." std.digit ("_" | std.digit)*)

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,7 +1,7 @@
 /* Hand-written tokenizers for JavaScript tokens that can't be
    expressed by lezer's built-in tokenizer. */
 
-import {ExternalTokenizer, ContextTracker} from "lezer"
+import {ExternalTokenizer, ContextTracker} from "@lezer/lr"
 import {insertSemi, noSemi, incdec, incdecPrefix, templateContent, templateDollarBrace, templateEnd,
         spaces, newline, BlockComment, LineComment,
         TSExtends, Dialect_ts} from "./parser.terms.js"

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -3,26 +3,19 @@
 
 import {ExternalTokenizer, ContextTracker} from "lezer"
 import {insertSemi, noSemi, incdec, incdecPrefix, templateContent, templateDollarBrace, templateEnd,
-        whitespace, BlockComment, LineComment,
+        spaces, newline, BlockComment, LineComment,
         TSExtends, Dialect_ts} from "./parser.terms.js"
 
-const newline = [10, 13, 8232, 8233]
-const space = [9, 11, 12, 32, 133, 160, 5760, 8192, 8193, 8194, 8195, 8196, 8197, 8198, 8199, 8200, 8201, 8202, 8239, 8287, 12288]
+const space = [9, 10, 11, 12, 13, 32, 133, 160, 5760, 8192, 8193, 8194, 8195, 8196, 8197, 8198, 8199, 8200,
+               8201, 8202, 8232, 8233, 8239, 8287, 12288]
 
 const braceR = 125, braceL = 123, semicolon = 59, slash = 47, star = 42,
       plus = 43, minus = 45, dollar = 36, backtick = 96, backslash = 92
 
 export const trackNewline = new ContextTracker({
   start: false,
-  shift(context, term, input, stack, from, to) {
-    if (term == LineComment || term == BlockComment) return context
-    if (term != whitespace) return false
-    if (!context) {
-      let space = input.read(from, to)
-      for (let i = 0; i < space.length; i++)
-        if (newline.indexOf(space.charCodeAt(i)) > -1) context = true
-    }
-    return context
+  shift(context, term) {
+    return term == LineComment || term == BlockComment || term == spaces ? context : term == newline
   },
   strict: false
 })
@@ -35,7 +28,7 @@ export const insertSemicolon = new ExternalTokenizer((input, stack) => {
 
 export const noSemicolon = new ExternalTokenizer((input, stack) => {
   let {next} = input, after
-  if (space.indexOf(next) > -1 || newline.indexOf(next) > -1) return
+  if (space.indexOf(next) > -1) return
   if (next == slash && ((after = input.peek(1)) == slash || after == star)) return
   if (next != braceR && next != semicolon && next != -1 && !stack.context && stack.canShift(noSemi))
     input.acceptToken(noSemi)

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -277,7 +277,7 @@ const {foo#bar} = {};
 
 Script(VariableDeclaration(
   const,
-  ObjectPattern("{",PatternProperty(PropertyName,⚠,VariableDefinition),"}"),
+  ObjectPattern("{",PatternProperty(PropertyName,⚠),"}"),
   Equals,
   ObjectExpression))
 

--- a/test/test-javascript.js
+++ b/test/test-javascript.js
@@ -1,5 +1,5 @@
 import {parser} from "../dist/index.es.js"
-import {fileTests} from "lezer-generator/dist/test"
+import {fileTests} from "@lezer/generator/dist/test"
 
 import * as fs from "fs"
 import * as path from "path"

--- a/test/typescript.txt
+++ b/test/typescript.txt
@@ -140,3 +140,12 @@ Script(VariableDeclaration(let, VariableDefinition, Equals, ArrowFunction(
   TypeAnnotation(TypeName),
   Arrow,
   VariableName)))
+
+# Template types {"dialect": "ts"}
+
+type Tmpl<T> = `${string} ${5}` | `one ${Two}`
+
+==>
+
+Script(TypeAliasDeclaration(type, TypeDefinition, TypeParamList(TypeDefinition), Equals,
+  UnionType(TemplateType(TypeName, LiteralType(Number)), LogicOp, TemplateType(TypeName))))


### PR DESCRIPTION
tried to pull in upstream changes to our fork in order to get the latest minor version bumps for other codemirror packages (e.g. https://github.com/codemirror/language/releases/tag/0.19.0), but for some reason it busts the named class / function cells… i can’t see any reason why the [changes](https://github.com/lezer-parser/javascript/compare/0.13.4...main) in the latest release would break these two tests:
<img width="878" alt="Screen Shot 2021-08-16 at 7 21 35 PM" src="https://user-images.githubusercontent.com/20714654/129654678-0594ceb3-e4b8-4f56-bb9c-48a9fdecc246.png">

i've tried a handful of things around `@dynamicPrecedence` and the `cellname` precedence we defined but can't get anything to function properly... maybe it's an issue in one of the packages further upstream like [`@lezer/lr`](https://github.com/lezer-parser/lr/compare/0.13.5...main)??? or maybe i'm missing something totally obvious... if you have any ideas, please feel free to update this branch directly... feeling pretty stumped at the moment