### PR TITLE
CodeMirror upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.15.2 (2021-12-08)
+
+### Bug fixes
+
+Fix a typo in the `TaggedTemplateExpression` node name. Support n suffixes after non-decimal integers
+
+Add support for non-decimal bignum literals ().
+
+Add support for static class initialization blocks.
+
 ## 0.15.1 (2021-11-12)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.15.1 (2021-11-12)
+
+### Bug fixes
+
+Add support for TypeScript `import {type X} from y` syntax.
+
+Indexed TypeScript types can now take type parameters.
+
+Add support for private field syntax.
+
+Rename PropertyNameDefinition node to PropertyDefinition for consistency with other names.
+
+### New features
+
+Recognize TypeScript 4.3's `override` keyword.
+
 ## 0.15.0 (2021-08-11)
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lezer-javascript
+# @lezer/javascript
 
 This is a JavaScript grammar for the
 [lezer](https://lezer.codemirror.net/) parser system.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/lezer",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A Lezer grammar for Observable JavaScript",
   "main": "dist/index.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lezer/javascript",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "lezer-based JavaScript grammar",
   "main": "dist/index.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lezer/javascript",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "lezer-based JavaScript grammar",
   "main": "dist/index.cjs",
   "type": "module",

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -108,7 +108,7 @@ MethodDeclaration[group=ClassItem] {
   pkwMod<"static">?
   pkwMod<"async">?
   (pkwMod<"get"> | pkwMod<"set"> | Star)?
-  PropertyNameDefinition
+  PropertyDefinition
   ParamList
   Block
 }
@@ -116,7 +116,7 @@ MethodDeclaration[group=ClassItem] {
 PropertyDeclaration[group=ClassItem] {
   pkwMod<"static">?
   pkwMod<"readonly">?
-  PropertyNameDefinition
+  PropertyDefinition
   LogicOp<"!">?
   ("=" expressionNoComma)?
   semi
@@ -194,7 +194,7 @@ ArrayExpression {
   "[" commaSep1<"..."? expressionNoComma | ""> ~destructure "]"
 }
 
-propName { PropertyNameDefinition | "[" expression "]" | Number | String }
+propName { PropertyDefinition | "[" expression "]" | Number | String }
 
 Property {
   pkwMod<"async">? (pkwMod<"get"> | pkwMod<"set"> | Star)? propName ParamList Block |
@@ -303,7 +303,7 @@ Label { identifier }
 
 PropertyName { word }
 
-PropertyNameDefinition { word }
+PropertyDefinition { word }
 
 questionOp[@name=LogicOp] { "?" }
 

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -78,7 +78,7 @@ ImportDeclaration {
 }
 
 ImportGroup {
-  "{" commaSep<VariableDefinition | VariableName ckw<"as"> VariableDefinition> "}"
+  "{" commaSep<tskw<"type">? (VariableDefinition | VariableName ckw<"as"> VariableDefinition)> "}"
 }
 
 ForSpec {

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -587,9 +587,9 @@ questionOp[@name=LogicOp] { "?" }
     (std.digit ("_" | std.digit)* ("." ("_" | std.digit)*)? | "." std.digit ("_" | std.digit)*)
       (("e" | "E") ("+" | "-")? ("_" | std.digit)+)? |
     std.digit ("_" | std.digit)* "n" |
-    "0x" (std.digit | $[a-fA-F] | "_")+ |
-    "0b" $[01_]+ |
-    "0o" $[0-7_]+
+    "0x" (std.digit | $[a-fA-F] | "_")+ "n"? |
+    "0b" $[01_]+ "n"? |
+    "0o" $[0-7_]+ "n"?
   }
 
   String {

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -264,7 +264,7 @@ expressionNoComma {
   AssignmentExpression |
   PostfixExpression { expressionNoComma !postfix (incdec | LogicOp<"!">) } |
   CallExpression { expressionNoComma !call TypeArgList? ArgList } |
-  TaggedTemplatExpression { expressionNoComma !taggedTemplate TemplateString } |
+  TaggedTemplateExpression { expressionNoComma !taggedTemplate TemplateString } |
   DynamicImport { kw<"import"> "(" expressionNoComma ")" } |
   ImportMeta { kw<"import"> "." PropertyName } |
   JSXElement |

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -137,7 +137,7 @@ MethodDeclaration[group=ClassItem] {
   tsPkwMod<"override">?
   pkwMod<"async">?
   (pkwMod<"get"> | pkwMod<"set"> | Star)?
-  (PropertyNameDefinition | PrivatePropertyDefinition)
+  (PropertyDefinition | PrivatePropertyDefinition)
   functionSignature
   Block
 }
@@ -146,7 +146,7 @@ PropertyDeclaration[group=ClassItem] {
   privacy?
   (pkwMod<"static"> | tsPkwMod<"abstract">)?
   pkwMod<"readonly">?
-  (PropertyNameDefinition | PrivatePropertyDefinition)
+  (PropertyDefinition | PrivatePropertyDefinition)
   (Optional | LogicOp<"!">)?
   TypeAnnotation?
   ("=" expressionNoComma)?
@@ -170,7 +170,7 @@ EnumDeclaration {
 }
 
 NamespaceDeclaration {
-  (tskw<"namespace"> | tskw<"module">) VariableDefinition ("." PropertyNameDefinition)* Block
+  (tskw<"namespace"> | tskw<"module">) VariableDefinition ("." PropertyDefinition)* Block
 }
 
 AmbientDeclaration {
@@ -188,7 +188,7 @@ AmbientDeclaration {
       ClassBody { "{" (
         MethodDeclaration {
           privacy? (pkwMod<"static"> | tsPkwMod<"abstract">)? pkwMod<"async">? (pkwMod<"get"> | pkwMod<"set"> | Star)?
-          (PropertyNameDefinition | PrivatePropertyDefinition) TypeParamList? ParamList (TypeAnnotation | TypePredicate) semi
+          (PropertyDefinition | PrivatePropertyDefinition) TypeParamList? ParamList (TypeAnnotation | TypePredicate) semi
         } |
         PropertyDeclaration |        
         IndexSignature
@@ -280,7 +280,7 @@ ArrayExpression {
   "[" commaSep1<"..."? expressionNoComma | ""> ~destructure "]"
 }
 
-propName { PropertyNameDefinition | "[" expression "]" | Number | String }
+propName { PropertyDefinition | "[" expression "]" | Number | String }
 
 Property {
   pkwMod<"async">? (pkwMod<"get"> | pkwMod<"set"> | Star)? propName functionSignature Block |
@@ -401,20 +401,20 @@ ObjectType {
 }
 
 IndexSignature {
-  pkwMod<"readonly">? "[" PropertyNameDefinition (TypeAnnotation | kw<"in"> type) "]" TypeAnnotation semi
+  pkwMod<"readonly">? "[" PropertyDefinition (TypeAnnotation | kw<"in"> type) "]" TypeAnnotation semi
 }
 
 MethodType {
   pkwMod<"async">?
   (pkwMod<"get"> | pkwMod<"set"> | Star)?
-  PropertyNameDefinition
+  PropertyDefinition
   functionSignature
   semi
 }
 
 PropertyType {
   (ArithOp<"+" | "-">? pkwMod<"readonly">)?
-  PropertyNameDefinition
+  PropertyDefinition
   (ArithOp<"+" | "-">? Optional)?
   TypeAnnotation
   semi
@@ -520,7 +520,7 @@ Label { identifier }
 
 PropertyName { word }
 
-PropertyNameDefinition { word }
+PropertyDefinition { word }
 
 PrivatePropertyName { privateIdentifier }
 

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -134,6 +134,7 @@ privacyArg {
 MethodDeclaration[group=ClassItem] {
   privacy?
   (pkwMod<"static"> | tsPkwMod<"abstract">)?
+  pkwMod<"override">?
   pkwMod<"async">?
   (pkwMod<"get"> | pkwMod<"set"> | Star)?
   PropertyNameDefinition

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -134,10 +134,10 @@ privacyArg {
 MethodDeclaration[group=ClassItem] {
   privacy?
   (pkwMod<"static"> | tsPkwMod<"abstract">)?
-  pkwMod<"override">?
+  tsPkwMod<"override">?
   pkwMod<"async">?
   (pkwMod<"get"> | pkwMod<"set"> | Star)?
-  PropertyNameDefinition
+  (PropertyNameDefinition | PrivatePropertyDefinition)
   functionSignature
   Block
 }
@@ -146,7 +146,7 @@ PropertyDeclaration[group=ClassItem] {
   privacy?
   (pkwMod<"static"> | tsPkwMod<"abstract">)?
   pkwMod<"readonly">?
-  PropertyNameDefinition
+  (PropertyNameDefinition | PrivatePropertyDefinition)
   (Optional | LogicOp<"!">)?
   TypeAnnotation?
   ("=" expressionNoComma)?
@@ -188,7 +188,7 @@ AmbientDeclaration {
       ClassBody { "{" (
         MethodDeclaration {
           privacy? (pkwMod<"static"> | tsPkwMod<"abstract">)? pkwMod<"async">? (pkwMod<"get"> | pkwMod<"set"> | Star)?
-          PropertyNameDefinition TypeParamList? ParamList (TypeAnnotation | TypePredicate) semi
+          (PropertyNameDefinition | PrivatePropertyDefinition) TypeParamList? ParamList (TypeAnnotation | TypePredicate) semi
         } |
         PropertyDeclaration |        
         IndexSignature
@@ -331,7 +331,7 @@ AssignmentExpression {
 }
 
 MemberExpression {
-  expressionNoComma !member (("." | "?.") PropertyName | "[" expression "]")
+  expressionNoComma !member (("." | "?.") (PropertyName | PrivatePropertyName) | "[" expression "]")
 }
 
 ArgList {
@@ -373,7 +373,7 @@ type[@isGroup=Type] {
   ParenthesizedType { "(" type ")" } |
   FunctionSignature { ParamTypeList "=>" type } |
   NewSignature { kw<"new"> ParamTypeList "=>" type } |
-  IndexedType { type !typeMember ("." PropertyName | "[" (String | Number) "]")+ } |
+  IndexedType |
   TupleType { "[" commaSep<(Label ":")? type | "..." type> "]" } |
   ArrayType { type "[" "]" | type "[" "]" } |
   ReadonlyType { tskw<"readonly"> !readonly type } |
@@ -381,8 +381,12 @@ type[@isGroup=Type] {
   UnionType { type !union LogicOp { "|" } type } |
   IntersectionType { type !intersection LogicOp { "&" } type } |
   ConditionalType { type !typeTernary questionOp ~arrow type LogicOp<":"> type } |
-  ParameterizedType { TypeName !typeargs TypeArgList } |
+  ParameterizedType { (TypeName | IndexedType) !typeargs TypeArgList } |
   TypeName
+}
+
+IndexedType {
+  type !typeMember ("." TypeName | "[" (String | Number) "]")+
 }
 
 ObjectType {
@@ -518,6 +522,10 @@ PropertyName { word }
 
 PropertyNameDefinition { word }
 
+PrivatePropertyName { privateIdentifier }
+
+PrivatePropertyDefinition { privateIdentifier }
+
 Optional { "?" }
 
 questionOp[@name=LogicOp] { "?" }
@@ -526,7 +534,7 @@ questionOp[@name=LogicOp] { "?" }
 
 @context trackNewline from "./tokens.js"
 
-@external extend { identifier } tsExtends from "./tokens" { TSExtends[@name=extends] }
+@external specialize { identifier } tsExtends from "./tokens" { TSExtends[@name=extends] }
 
 @external tokens noSemicolon from "./tokens" { noSemi }
 
@@ -565,6 +573,8 @@ questionOp[@name=LogicOp] { "?" }
   word { identifierChar (identifierChar | std.digit)* }
 
   identifier { word }
+
+  privateIdentifier { "#" word }
 
   @precedence { spaces, newline, identifier }
 

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -120,7 +120,7 @@ ClassDeclaration {
 }
 
 ClassBody {
-  "{" (MethodDeclaration | PropertyDeclaration | ";")* "}"
+  "{" (MethodDeclaration | PropertyDeclaration | StaticBlock | ";")* "}"
 }
 
 privacy {
@@ -140,6 +140,10 @@ MethodDeclaration[group=ClassItem] {
   (PropertyDefinition | PrivatePropertyDefinition)
   functionSignature
   Block
+}
+
+StaticBlock[group=ClassItem] {
+  pkwMod<"static"> Block
 }
 
 PropertyDeclaration[group=ClassItem] {

--- a/src/javascript.grammar
+++ b/src/javascript.grammar
@@ -314,7 +314,8 @@ BinaryExpression {
   expressionNoComma !times (divide | ArithOp<"%"> | ArithOp<"*">) expressionNoComma |
   expressionNoComma !plus ArithOp<"+" | "-"> expressionNoComma |
   expressionNoComma !shift BitOp<">>" ">"? | "<<"> expressionNoComma |
-  expressionNoComma !rel (LessThan | CompareOp<"<=" | ">" "="?> | kw<"in"> | kw<"instanceof">) expressionNoComma |
+  expressionNoComma !rel (LessThan | CompareOp<"<=" | ">" "="?> | kw<"instanceof">) expressionNoComma |
+  (expressionNoComma | PrivatePropertyName) !rel kw<"in"> expressionNoComma |
   expressionNoComma !rel ckw<"as"> (kw<"const"> | type) |
   expressionNoComma !equal CompareOp<"==" "="? | "!=" "="?> expressionNoComma |
   expressionNoComma !bitOr BitOp { "|" } expressionNoComma |

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -207,8 +207,8 @@ Cell(
 ==>
 
 Cell(ExpressionStatement(ParenthesizedExpression(ObjectExpression(
-  Property(PropertyNameDefinition,ArrowFunction(ParamList,Arrow,Number)),
-  Property(PropertyNameDefinition,String)))))
+  Property(PropertyDefinition,ArrowFunction(ParamList,Arrow,Number)),
+  Property(PropertyDefinition,String)))))
 
 # Long potential arrow function
 
@@ -442,11 +442,11 @@ foo({},
 
 Cell(ExpressionStatement(CallExpression(VariableName,ArgList(
   ObjectExpression,
-  ObjectExpression(Property(PropertyNameDefinition,String)),
-  ObjectExpression(Property(PropertyNameDefinition,String),Property(String,VariableName),Property(Number,Number)),
-  ObjectExpression(Property(PropertyNameDefinition),Property(VariableName,ParamList,Block)),
-  ObjectExpression(Property(PropertyNameDefinition),Property(PropertyNameDefinition)),
-  ObjectExpression(Property(PropertyNameDefinition))))))
+  ObjectExpression(Property(PropertyDefinition,String)),
+  ObjectExpression(Property(PropertyDefinition,String),Property(String,VariableName),Property(Number,Number)),
+  ObjectExpression(Property(PropertyDefinition),Property(VariableName,ParamList,Block)),
+  ObjectExpression(Property(PropertyDefinition),Property(PropertyDefinition)),
+  ObjectExpression(Property(PropertyDefinition))))))
 
 # Method definitions
 
@@ -469,14 +469,14 @@ Cell(ExpressionStatement(CallExpression(VariableName,ArgList(
 ==>
 
 Cell(ExpressionStatement(ParenthesizedExpression(ObjectExpression(
-  Property(PropertyNameDefinition,BooleanLiteral),
-  Property(PropertyNameDefinition,ParamList(VariableDefinition,VariableDefinition),
+  Property(PropertyDefinition,BooleanLiteral),
+  Property(PropertyDefinition,ParamList(VariableDefinition,VariableDefinition),
     Block(ReturnStatement(return,BinaryExpression(VariableName,ArithOp,VariableName)))),
-  Property(get,PropertyNameDefinition,ParamList,Block(ReturnStatement(return,VariableName))),
-  Property(set,PropertyNameDefinition,ParamList(VariableDefinition),
+  Property(get,PropertyDefinition,ParamList,Block(ReturnStatement(return,VariableName))),
+  Property(set,PropertyDefinition,ParamList(VariableDefinition),
     Block(ExpressionStatement(AssignmentExpression(VariableName,Equals,VariableName)))),
-  Property(Star,PropertyNameDefinition,ParamList,Block(ExpressionStatement(UnaryExpression(yield,VariableName)))),
-  Property(PropertyNameDefinition,ParamList,Block(ReturnStatement(return,Number)))))))
+  Property(Star,PropertyDefinition,ParamList,Block(ExpressionStatement(UnaryExpression(yield,VariableName)))),
+  Property(PropertyDefinition,ParamList,Block(ReturnStatement(return,Number)))))))
 
 # Keyword property names
 
@@ -492,12 +492,12 @@ Cell(ExpressionStatement(ParenthesizedExpression(ObjectExpression(
 ==>
 
 Cell(ExpressionStatement(ParenthesizedExpression(ObjectExpression(
-  Property(PropertyNameDefinition,ParamList,Block),
-  Property(PropertyNameDefinition,ParamList,Block),
-  Property(PropertyNameDefinition,FunctionExpression(function,ParamList,Block)),
-  Property(PropertyNameDefinition,ParamList,Block),
-  Property(PropertyNameDefinition,BooleanLiteral),
-  Property(PropertyNameDefinition,BooleanLiteral)))))
+  Property(PropertyDefinition,ParamList,Block),
+  Property(PropertyDefinition,ParamList,Block),
+  Property(PropertyDefinition,FunctionExpression(function,ParamList,Block)),
+  Property(PropertyDefinition,ParamList,Block),
+  Property(PropertyDefinition,BooleanLiteral),
+  Property(PropertyDefinition,BooleanLiteral)))))
 
 # Generator functions
 
@@ -740,7 +740,7 @@ Cell(Block(
 Cell(Block(
   ExpressionStatement(SequenceExpression(AssignmentExpression(VariableName,Equals,Number),AssignmentExpression(VariableName,Equals,Number))),
   ExpressionStatement(AssignmentExpression(VariableName,Equals,ObjectExpression(
-    Property(PropertyNameDefinition,ParenthesizedExpression(SequenceExpression(Number,BinaryExpression(Number,ArithOp,Number)))))))))
+    Property(PropertyDefinition,ParenthesizedExpression(SequenceExpression(Number,BinaryExpression(Number,ArithOp,Number)))))))))
 
 # Punctuation
 

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -333,7 +333,7 @@ Script(
   ExpressionStatement(TemplateString(VariableName)),
   ExpressionStatement(TemplateString),
   ExpressionStatement(TemplateString(TemplateString(TemplateString))),
-  ExpressionStatement(TaggedTemplatExpression(VariableName,TemplateString(VariableName))))
+  ExpressionStatement(TaggedTemplateExpression(VariableName,TemplateString(VariableName))))
 
 # Atoms
 

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -156,8 +156,8 @@ Script(
 ==>
 
 Script(ExpressionStatement(ParenthesizedExpression(ObjectExpression(
-  Property(PropertyNameDefinition,ArrowFunction(ParamList,Arrow,Number)),
-  Property(PropertyNameDefinition,String)))))
+  Property(PropertyDefinition,ArrowFunction(ParamList,Arrow,Number)),
+  Property(PropertyDefinition,String)))))
 
 # Long potential arrow function
 
@@ -368,11 +368,11 @@ foo({},
 
 Script(ExpressionStatement(CallExpression(VariableName,ArgList(
   ObjectExpression,
-  ObjectExpression(Property(PropertyNameDefinition,String)),
-  ObjectExpression(Property(PropertyNameDefinition,String),Property(String,VariableName),Property(Number,Number)),
-  ObjectExpression(Property(PropertyNameDefinition),Property(VariableName,ParamList,Block)),
-  ObjectExpression(Property(PropertyNameDefinition),Property(PropertyNameDefinition)),
-  ObjectExpression(Property(PropertyNameDefinition))))))
+  ObjectExpression(Property(PropertyDefinition,String)),
+  ObjectExpression(Property(PropertyDefinition,String),Property(String,VariableName),Property(Number,Number)),
+  ObjectExpression(Property(PropertyDefinition),Property(VariableName,ParamList,Block)),
+  ObjectExpression(Property(PropertyDefinition),Property(PropertyDefinition)),
+  ObjectExpression(Property(PropertyDefinition))))))
 
 # Method definitions
 
@@ -395,14 +395,14 @@ Script(ExpressionStatement(CallExpression(VariableName,ArgList(
 ==>
 
 Script(ExpressionStatement(ParenthesizedExpression(ObjectExpression(
-  Property(PropertyNameDefinition,BooleanLiteral),
-  Property(PropertyNameDefinition,ParamList(VariableDefinition,VariableDefinition),
+  Property(PropertyDefinition,BooleanLiteral),
+  Property(PropertyDefinition,ParamList(VariableDefinition,VariableDefinition),
     Block(ReturnStatement(return,BinaryExpression(VariableName,ArithOp,VariableName)))),
-  Property(get,PropertyNameDefinition,ParamList,Block(ReturnStatement(return,VariableName))),
-  Property(set,PropertyNameDefinition,ParamList(VariableDefinition),
+  Property(get,PropertyDefinition,ParamList,Block(ReturnStatement(return,VariableName))),
+  Property(set,PropertyDefinition,ParamList(VariableDefinition),
     Block(ExpressionStatement(AssignmentExpression(VariableName,Equals,VariableName)))),
-  Property(Star,PropertyNameDefinition,ParamList,Block(ExpressionStatement(UnaryExpression(yield,VariableName)))),
-  Property(PropertyNameDefinition,ParamList,Block(ReturnStatement(return,Number)))))))
+  Property(Star,PropertyDefinition,ParamList,Block(ExpressionStatement(UnaryExpression(yield,VariableName)))),
+  Property(PropertyDefinition,ParamList,Block(ReturnStatement(return,Number)))))))
 
 # Keyword property names
 
@@ -418,12 +418,12 @@ Script(ExpressionStatement(ParenthesizedExpression(ObjectExpression(
 ==>
 
 Script(ExpressionStatement(ParenthesizedExpression(ObjectExpression(
-  Property(PropertyNameDefinition,ParamList,Block),
-  Property(PropertyNameDefinition,ParamList,Block),
-  Property(PropertyNameDefinition,FunctionExpression(function,ParamList,Block)),
-  Property(PropertyNameDefinition,ParamList,Block),
-  Property(PropertyNameDefinition,BooleanLiteral),
-  Property(PropertyNameDefinition,BooleanLiteral)))))
+  Property(PropertyDefinition,ParamList,Block),
+  Property(PropertyDefinition,ParamList,Block),
+  Property(PropertyDefinition,FunctionExpression(function,ParamList,Block)),
+  Property(PropertyDefinition,ParamList,Block),
+  Property(PropertyDefinition,BooleanLiteral),
+  Property(PropertyDefinition,BooleanLiteral)))))
 
 # Generator functions
 
@@ -642,7 +642,7 @@ c = {d: (3, 4 + 5)};
 Script(
   ExpressionStatement(SequenceExpression(AssignmentExpression(VariableName,Equals,Number),AssignmentExpression(VariableName,Equals,Number))),
   ExpressionStatement(AssignmentExpression(VariableName,Equals,ObjectExpression(
-    Property(PropertyNameDefinition,ParenthesizedExpression(SequenceExpression(Number,BinaryExpression(Number,ArithOp,Number))))))))
+    Property(PropertyDefinition,ParenthesizedExpression(SequenceExpression(Number,BinaryExpression(Number,ArithOp,Number))))))))
 
 # Punctuation
 

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -40,7 +40,7 @@ Cell(Block(
 
 Cell(Block(
   FunctionDeclaration(async,function,VariableDefinition,ParamList,Block),
-  ClassDeclaration(class,VariableDefinition,ClassBody(MethodDeclaration(async,PropertyNameDefinition,ParamList,Block))),
+  ClassDeclaration(class,VariableDefinition,ClassBody(MethodDeclaration(async,PropertyDefinition,ParamList,Block))),
   ExpressionStatement(ArrowFunction(async,ParamList(VariableDefinition),Arrow,Block(ReturnStatement(return,VariableName))))))
 
 # If statements
@@ -204,12 +204,12 @@ Cell(Block(LabeledStatement(Label,ForStatement(for,ForSpec,Block(
 
 Cell(Block(
   ClassDeclaration(class,VariableDefinition,ClassBody(
-    MethodDeclaration(static,PropertyNameDefinition,ParamList(VariableDefinition),Block(ReturnStatement(return,VariableName))),
-    MethodDeclaration(PropertyNameDefinition,ParamList(VariableDefinition),Block(ReturnStatement(return,VariableName))),
-    MethodDeclaration(PropertyNameDefinition,ParamList,Block))),
+    MethodDeclaration(static,PropertyDefinition,ParamList(VariableDefinition),Block(ReturnStatement(return,VariableName))),
+    MethodDeclaration(PropertyDefinition,ParamList(VariableDefinition),Block(ReturnStatement(return,VariableName))),
+    MethodDeclaration(PropertyDefinition,ParamList,Block))),
   ClassDeclaration(class,VariableDefinition,extends,CallExpression(VariableName,ArgList(String)),ClassBody(
-    MethodDeclaration(PropertyNameDefinition,ParamList,Block(ExpressionStatement(CallExpression(super,ArgList)))),
-    MethodDeclaration(PropertyNameDefinition,ParamList,Block(ExpressionStatement(CallExpression(MemberExpression(super,PropertyName),ArgList))))))))
+    MethodDeclaration(PropertyDefinition,ParamList,Block(ExpressionStatement(CallExpression(super,ArgList)))),
+    MethodDeclaration(PropertyDefinition,ParamList,Block(ExpressionStatement(CallExpression(MemberExpression(super,PropertyName),ArgList))))))))
 
 # Empty statements
 

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -178,6 +178,7 @@ class Foo extends require('another-class') {
   bar() { super.a(); }
   prop;
   etc = 20;
+  static { f() }
 }
 
 ==>
@@ -191,7 +192,8 @@ Script(
     MethodDeclaration(PropertyDefinition,ParamList,Block(ExpressionStatement(CallExpression(super,ArgList)))),
     MethodDeclaration(PropertyDefinition,ParamList,Block(ExpressionStatement(CallExpression(MemberExpression(super,PropertyName),ArgList)))),
     PropertyDeclaration(PropertyDefinition),
-    PropertyDeclaration(PropertyDefinition,Equals,Number))))
+    PropertyDeclaration(PropertyDefinition,Equals,Number),
+    StaticBlock(static, Block(ExpressionStatement(CallExpression(VariableName,ArgList)))))))
 
 # Private properties
 

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -34,7 +34,7 @@ async (a) => { return foo; };
 
 Script(
   FunctionDeclaration(async,function,VariableDefinition,ParamList,Block),
-  ClassDeclaration(class,VariableDefinition,ClassBody(MethodDeclaration(async,PropertyNameDefinition,ParamList,Block))),
+  ClassDeclaration(class,VariableDefinition,ClassBody(MethodDeclaration(async,PropertyDefinition,ParamList,Block))),
   ExpressionStatement(ArrowFunction(async,ParamList(VariableDefinition),Arrow,Block(ReturnStatement(return,VariableName)))))
 
 # If statements
@@ -184,14 +184,14 @@ class Foo extends require('another-class') {
 
 Script(
   ClassDeclaration(class,VariableDefinition,ClassBody(
-    MethodDeclaration(static,PropertyNameDefinition,ParamList(VariableDefinition),Block(ReturnStatement(return,VariableName))),
-    MethodDeclaration(PropertyNameDefinition,ParamList(VariableDefinition),Block(ReturnStatement(return,VariableName))),
-    MethodDeclaration(PropertyNameDefinition,ParamList,Block))),
+    MethodDeclaration(static,PropertyDefinition,ParamList(VariableDefinition),Block(ReturnStatement(return,VariableName))),
+    MethodDeclaration(PropertyDefinition,ParamList(VariableDefinition),Block(ReturnStatement(return,VariableName))),
+    MethodDeclaration(PropertyDefinition,ParamList,Block))),
   ClassDeclaration(class,VariableDefinition,extends,CallExpression(VariableName,ArgList(String)),ClassBody(
-    MethodDeclaration(PropertyNameDefinition,ParamList,Block(ExpressionStatement(CallExpression(super,ArgList)))),
-    MethodDeclaration(PropertyNameDefinition,ParamList,Block(ExpressionStatement(CallExpression(MemberExpression(super,PropertyName),ArgList)))),
-    PropertyDeclaration(PropertyNameDefinition),
-    PropertyDeclaration(PropertyNameDefinition,Equals,Number))))
+    MethodDeclaration(PropertyDefinition,ParamList,Block(ExpressionStatement(CallExpression(super,ArgList)))),
+    MethodDeclaration(PropertyDefinition,ParamList,Block(ExpressionStatement(CallExpression(MemberExpression(super,PropertyName),ArgList)))),
+    PropertyDeclaration(PropertyDefinition),
+    PropertyDeclaration(PropertyDefinition,Equals,Number))))
 
 # Private properties
 

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -196,7 +196,7 @@ Script(
 # Private properties
 
 class Foo {
-  #bar() { this.#a() + this?.#prop; }
+  #bar() { this.#a() + this?.#prop == #prop in this; }
   #prop;
   #etc = 20;
 }
@@ -206,9 +206,12 @@ class Foo {
 Script(ClassDeclaration(class,VariableDefinition,ClassBody(
   MethodDeclaration(PrivatePropertyDefinition,ParamList,Block(
     ExpressionStatement(BinaryExpression(
-       CallExpression(MemberExpression(this,PrivatePropertyName),ArgList),
-       ArithOp,
-       MemberExpression(this,PrivatePropertyName))))),
+       BinaryExpression(
+         CallExpression(MemberExpression(this,PrivatePropertyName),ArgList),
+         ArithOp,
+         MemberExpression(this,PrivatePropertyName)),
+       CompareOp,
+       BinaryExpression(PrivatePropertyName, in, this))))),
   PropertyDeclaration(PrivatePropertyDefinition),
   PropertyDeclaration(PrivatePropertyDefinition,Equals,Number))))
 
@@ -294,7 +297,7 @@ Script(
 
 # Recover from invalid char
 
-const {foo#bar} = {};
+const {foobar} = {};
 
 ==>
 

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -176,6 +176,7 @@ class Foo {
 class Foo extends require('another-class') {
   constructor() { super(); }
   bar() { super.a(); }
+  override baz() {}
 }
 
 ==>
@@ -187,7 +188,8 @@ Script(
     MethodDeclaration(PropertyNameDefinition,ParamList,Block))),
   ClassDeclaration(class,VariableDefinition,extends,CallExpression(VariableName,ArgList(String)),ClassBody(
     MethodDeclaration(PropertyNameDefinition,ParamList,Block(ExpressionStatement(CallExpression(super,ArgList)))),
-    MethodDeclaration(PropertyNameDefinition,ParamList,Block(ExpressionStatement(CallExpression(MemberExpression(super,PropertyName),ArgList)))))))
+    MethodDeclaration(PropertyNameDefinition,ParamList,Block(ExpressionStatement(CallExpression(MemberExpression(super,PropertyName),ArgList)))),
+    MethodDeclaration(override, PropertyNameDefinition,ParamList,Block))))
 
 # Imports
 

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -176,7 +176,8 @@ class Foo {
 class Foo extends require('another-class') {
   constructor() { super(); }
   bar() { super.a(); }
-  override baz() {}
+  prop;
+  etc = 20;
 }
 
 ==>
@@ -189,7 +190,27 @@ Script(
   ClassDeclaration(class,VariableDefinition,extends,CallExpression(VariableName,ArgList(String)),ClassBody(
     MethodDeclaration(PropertyNameDefinition,ParamList,Block(ExpressionStatement(CallExpression(super,ArgList)))),
     MethodDeclaration(PropertyNameDefinition,ParamList,Block(ExpressionStatement(CallExpression(MemberExpression(super,PropertyName),ArgList)))),
-    MethodDeclaration(override, PropertyNameDefinition,ParamList,Block))))
+    PropertyDeclaration(PropertyNameDefinition),
+    PropertyDeclaration(PropertyNameDefinition,Equals,Number))))
+
+# Private properties
+
+class Foo {
+  #bar() { this.#a() + this?.#prop; }
+  #prop;
+  #etc = 20;
+}
+
+==>
+
+Script(ClassDeclaration(class,VariableDefinition,ClassBody(
+  MethodDeclaration(PrivatePropertyDefinition,ParamList,Block(
+    ExpressionStatement(BinaryExpression(
+       CallExpression(MemberExpression(this,PrivatePropertyName),ArgList),
+       ArithOp,
+       MemberExpression(this,PrivatePropertyName))))),
+  PropertyDeclaration(PrivatePropertyDefinition),
+  PropertyDeclaration(PrivatePropertyDefinition,Equals,Number))))
 
 # Imports
 

--- a/test/typescript.txt
+++ b/test/typescript.txt
@@ -149,3 +149,13 @@ type Tmpl<T> = `${string} ${5}` | `one ${Two}`
 
 Script(TypeAliasDeclaration(type, TypeDefinition, TypeParamList(TypeDefinition), Equals,
   UnionType(TemplateType(TypeName, LiteralType(Number)), LogicOp, TemplateType(TypeName))))
+
+# Extending complex types {"dialect": "ts"}
+
+class Foo extends A.B<Param> {}
+
+==>
+
+Script(ClassDeclaration(class, VariableDefinition,
+  extends, ParameterizedType(IndexedType(TypeName, TypeName), TypeArgList(TypeName)),
+  ClassBody))

--- a/test/typescript.txt
+++ b/test/typescript.txt
@@ -48,11 +48,11 @@ interface Foo {
 ==>
 
 Script(InterfaceDeclaration(interface, TypeDefinition, ObjectType(
-  PropertyType(readonly, PropertyNameDefinition, TypeAnnotation(TypeName)),
-  MethodType(PropertyNameDefinition, ParamList(VariableDefinition, TypeAnnotation(TypeName)), TypeAnnotation(VoidType(void))),
+  PropertyType(readonly, PropertyDefinition, TypeAnnotation(TypeName)),
+  MethodType(PropertyDefinition, ParamList(VariableDefinition, TypeAnnotation(TypeName)), TypeAnnotation(VoidType(void))),
   CallSignature(ParamList(VariableDefinition, TypeAnnotation(TypeName)), TypeAnnotation(TypeName)),
   NewSignature(new,ParamList, TypeAnnotation(TypeName)),
-  IndexSignature(readonly, PropertyNameDefinition, TypeAnnotation(TypeName), TypeAnnotation(TypeName)))))
+  IndexSignature(readonly, PropertyDefinition, TypeAnnotation(TypeName), TypeAnnotation(TypeName)))))
 
 # Call type args {"dialect": "ts"}
 
@@ -120,13 +120,13 @@ Script(ClassDeclaration(
   extends ParameterizedType(TypeName, TypeArgList(TypeName)),
   implements TypeName,
   ClassBody(
-    PropertyDeclaration(PropertyNameDefinition, TypeAnnotation(TypeName)),
-    PropertyDeclaration(Privacy, readonly, PropertyNameDefinition, TypeAnnotation(TypeName), Equals, String),
-    MethodDeclaration(PropertyNameDefinition, ParamList(
+    PropertyDeclaration(PropertyDefinition, TypeAnnotation(TypeName)),
+    PropertyDeclaration(Privacy, readonly, PropertyDefinition, TypeAnnotation(TypeName), Equals, String),
+    MethodDeclaration(PropertyDefinition, ParamList(
       readonly, VariableDefinition, TypeAnnotation(TypeName),
       Privacy, VariableDefinition, TypeAnnotation(TypeName),
       VariableDefinition, TypeAnnotation(TypeName)), Block),
-    MethodDeclaration(Privacy, static, PropertyNameDefinition, ParamList, TypeAnnotation(VoidType(void)), Block))))
+    MethodDeclaration(Privacy, static, PropertyDefinition, ParamList, TypeAnnotation(VoidType(void)), Block))))
 
 # Arrow with type params {"dialect": "ts"}
 


### PR DESCRIPTION
This PR is an early step in properly fixing https://github.com/observablehq/observablehq/issues/5241, which requires pulling in CodeMirror updates to get a fix from Marijn. This may not be 100% required for those other upgrades, but figured I might as well.

This PR pulls in the latest changes from upstream and incorporates them. As part of this upgrade, we get support for [private class features](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) (the JavaScript kind using `#`, not the TypeScript kind using `private`), [static class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static), and better BigInt support.

Most of the changes in this PR are from the updated `yarn.lock` file.